### PR TITLE
Avoid idle rendering in the viewer

### DIFF
--- a/src/viewer/camera/cameraMovementDo.ts
+++ b/src/viewer/camera/cameraMovementDo.ts
@@ -67,6 +67,7 @@ export class CameraMovementDo extends CameraMovement {
         this._camera.target.copy(target);
         this._camera.camPerspective.camera.lookAt(target);
         this._camera.camPerspective.camera.up.set(0, 1, 0);
+        this._camera.notifyMovement();
     }
 
     private lockVector(position: THREE.Vector3, fallback: THREE.Vector3) {

--- a/src/viewer/camera/cameraMovementLerp.ts
+++ b/src/viewer/camera/cameraMovementLerp.ts
@@ -49,6 +49,7 @@ export class CameraLerp extends CameraMovement {
             this.onProgress = undefined;
         }
         this.onProgress?.(t);
+        this._camera.notifyMovement();
     }
 
     override move3(vector: THREE.Vector3): void {

--- a/src/viewer/inputs/keyboard.ts
+++ b/src/viewer/inputs/keyboard.ts
@@ -206,6 +206,7 @@ export class KeyboardHandler extends InputHandler {
         move.multiplyScalar(speed);
         if (this.arrowsEnabled) {
             this.camera.localVelocity = move;
+            this._viewer.requestRender();
         }
     }
 }

--- a/src/viewer/rendering/renderer.ts
+++ b/src/viewer/rendering/renderer.ts
@@ -71,6 +71,7 @@ export class Renderer {
     render() {
         if (!this.needsUpdate && !this.camera.hasMoved) return;
         this.renderer.render(this.scene, this.camera.camPerspective.camera);
+        this.needsUpdate = false;
     }
 
     add(target: THREE.Object3D) {

--- a/src/viewer/rendering/renderer.ts
+++ b/src/viewer/rendering/renderer.ts
@@ -68,6 +68,7 @@ export class Renderer {
         this.needsUpdate = true;
     }
 
+    // Render only when the scene/camera is marked dirty, then reset the flag.
     render() {
         if (!this.needsUpdate && !this.camera.hasMoved) return;
         this.renderer.render(this.scene, this.camera.camPerspective.camera);
@@ -92,6 +93,7 @@ export class Renderer {
 
     private _lastSize = new THREE.Vector2();
 
+    // Resize renderer output; invalidates the scene to re-render at new size.
     private fitViewport = () => {
         const size = this.viewport.getParentSize();
 

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -20,6 +20,7 @@ export class Viewer {
     updateId: number | null = null;
     clock = new THREE.Clock();
     scene = new THREE.Scene();
+    private _isIdle = true;
 
     constructor(options?: PartialSettings) {
         this.settings = getSettings(options);
@@ -47,6 +48,9 @@ export class Viewer {
         this.environment = new Environment(this.settings);
         this.environment.getObjects().forEach((o) => this.renderer.add(o));
         this.inputs.registerAll();
+        this.camera.onMoved.subscribe(() => this.requestRender());
+        this.camera.onValueChanged.sub(() => this.requestRender());
+        this.viewport.onResize.subscribe(() => this.requestRender());
         this.start();
     }
 
@@ -54,7 +58,7 @@ export class Viewer {
         if (this.running) return;
         this.running = true;
         this.clock.start();
-        this.animate();
+        this.requestRender();
     }
 
     stop() {
@@ -65,18 +69,36 @@ export class Viewer {
         }
     }
 
+    requestRender() {
+        if (!this.running) return;
+        if (this.updateId !== null) return;
+        if (this._isIdle) {
+            this.clock.getDelta();
+            this._isIdle = false;
+        }
+        this.updateId = requestAnimationFrame(this.animate);
+    }
+
     private animate = () => {
         if (!this.running) return;
-        this.updateId = requestAnimationFrame(this.animate);
+        this.updateId = null;
         const dt = this.clock.getDelta();
         const camChanged = this.camera.update(dt);
-        this.renderer.needsUpdate = this.renderer.needsUpdate || camChanged;
+        if (camChanged) {
+            this.renderer.needsUpdate = true;
+        }
         this.renderer.render();
+        if (camChanged || this.renderer.needsUpdate) {
+            this.requestRender();
+        } else {
+            this._isIdle = true;
+        }
     };
 
     add(obj: THREE.Object3D, frameCamera = true) {
         console.log('Adding object');
         this.renderer.needsUpdate = true;
+        this.requestRender();
         if (!this.renderer.add(obj)) {
             throw new Error('Could not load object');
         }
@@ -85,11 +107,13 @@ export class Viewer {
     remove(obj: THREE.Object3D) {
         console.log('Removing object');
         this.renderer.needsUpdate = true;
+        this.requestRender();
         this.renderer.remove(obj);
     }
 
     clear() {
         this.renderer.clear();
+        this.requestRender();
     }
 
     dispose() {

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -20,7 +20,6 @@ export class Viewer {
     updateId: number | null = null;
     clock = new THREE.Clock();
     scene = new THREE.Scene();
-    private _isIdle = true;
 
     constructor(options?: PartialSettings) {
         this.settings = getSettings(options);
@@ -57,7 +56,6 @@ export class Viewer {
     start() {
         if (this.running) return;
         this.running = true;
-        this.clock.start();
         this.requestRender();
     }
 
@@ -67,18 +65,24 @@ export class Viewer {
             cancelAnimationFrame(this.updateId);
             this.updateId = null;
         }
+        this.clock.stop();
     }
 
+    // Invalidation-driven render loop:
+    // requestRender schedules a single frame; animate decides whether to keep
+    // scheduling based on camera/scene changes and stops the clock when idle.
     requestRender() {
         if (!this.running) return;
         if (this.updateId !== null) return;
-        if (this._isIdle) {
+        if (!this.clock.running) {
+            this.clock.start();
             this.clock.getDelta();
-            this._isIdle = false;
         }
         this.updateId = requestAnimationFrame(this.animate);
     }
 
+    // Single-frame tick: update camera, render if needed, and reschedule if
+    // camera/scene changes are still in progress (e.g. lerp or input).
     private animate = () => {
         if (!this.running) return;
         this.updateId = null;
@@ -91,10 +95,11 @@ export class Viewer {
         if (camChanged || this.renderer.needsUpdate) {
             this.requestRender();
         } else {
-            this._isIdle = true;
+            this.clock.stop();
         }
     };
 
+    // Mark scene dirty and schedule a render for new content.
     add(obj: THREE.Object3D, frameCamera = true) {
         console.log('Adding object');
         this.renderer.needsUpdate = true;
@@ -111,6 +116,7 @@ export class Viewer {
         this.renderer.remove(obj);
     }
 
+    // Clear scene content and ensure a render happens for the empty state.
     clear() {
         this.renderer.clear();
         this.requestRender();


### PR DESCRIPTION
## Summary
- avoid continuous RAF by scheduling frames only when the camera or scene changes
- tie camera movement (including lerp and direct movement) into invalidation so renders resume during input
- clear renderer dirty flag after rendering and document the new flow for maintainability

## Why
Idle rendering wastes CPU/GPU and battery while the viewer is static. This change switches to an invalidation-driven loop so the viewer renders only when something visually changes.

## How
`Viewer.requestRender()` schedules a single frame, `animate()` updates the camera and renders only when dirty, then reschedules while changes continue. Camera movement now emits a movement signal for both direct and lerped changes, and renderer dirty flags reset after a successful draw.